### PR TITLE
Fix David-DM badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# grunt-autoprefixer [![Build Status](https://travis-ci.org/nDmitry/grunt-autoprefixer.png?branch=master)](https://travis-ci.org/nDmitry/grunt-autoprefixer) ![David](https://david-dm.org/nDmitry/generator-frontend.png)
+# grunt-autoprefixer
+[![Build Status](https://travis-ci.org/nDmitry/grunt-autoprefixer.png?branch=master)](https://travis-ci.org/nDmitry/grunt-autoprefixer) 
+[![Dependency Status](https://david-dm.org/nDmitry/grunt-autoprefixer.png)](https://david-dm.org/nDmitry/grunt-autoprefixer)
 
 > [Autoprefixer](https://github.com/ai/autoprefixer) parses CSS and adds vendor-prefixed CSS properties using the [Can I Use](http://caniuse.com/) database.
 


### PR DESCRIPTION
Was pointing to a different repo and linked to the image instead of the david-dm.org page.
Also drops it below the title line.
