### PR TITLE
Update Autoprefixer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "autoprefixer": "~1.0.20140117",
+    "autoprefixer": "~1.0.20140213",
     "diff": "~1.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Autoprefixer was updated yesterday to 1.0.20140213.

Also want to say thanks for the Grunt plugin, it's now used in [WordPress](https://core.trac.wordpress.org/ticket/27078).
