### PR TITLE
Added a warning if no source files were found. Stops silent failure.

### DIFF
--- a/tasks/autoprefixer.js
+++ b/tasks/autoprefixer.js
@@ -56,16 +56,11 @@ module.exports = function(grunt) {
         prefixer = autoprefixer(options.browsers, {cascade: options.cascade});
 
         this.files.forEach(function(f) {
-            f.src
-                .filter(function(filepath) {
+            if (!f.src.length) {
+                return grunt.fail.warn('No source files were found.');
+            }
 
-                    if (!grunt.file.exists(filepath)) {
-                        grunt.log.warn('Source file "' + filepath + '" not found.');
-                        return false;
-                    } else {
-                        return true;
-                    }
-                })
+            f.src
                 .forEach(function(filepath) {
                     var dest = f.dest || filepath;
                     var input = grunt.file.read(filepath);


### PR DESCRIPTION
Filtering over `f.src` when the array length is `0` causes silent failure of this task.

Grunt already ensures that you only have access to existing files in `this.files`, so a simple simple check on the length of `f.src` is enough here to give useful feedback to a user.
