### PR TITLE
Bumps chalk to 0.5.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "autoprefixer": "~2.1.0",
     "diff": "~1.0.8",
-    "chalk": "~0.4.0"
+    "chalk": "~0.5.0"
   },
   "devDependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
This version contains, amongst other things, a speed improvement larger than a factor fifty. Using this version may increase logging throughput.
