### PR TITLE
Adding the correct wording for version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can specify browsers actual for your project:
 
 ```js
 options: {
-  browsers: ['last 2 version', 'ie 8', 'ie 9']
+  browsers: ['last 2 versions', 'ie 8', 'ie 9']
 }
 ```
 


### PR DESCRIPTION
https://github.com/postcss/autoprefixer#browsers - seems like you need the word 'versions' not 'version'
