### PR TITLE
Update the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "LICENSE"
   ],
   "dependencies": {
-    "autoprefixer-core": "^5.0.0",
-    "diff": "~1.2.1",
-    "chalk": "~0.5.0"
+    "autoprefixer-core": "^5.1.7",
+    "diff": "~1.3.0",
+    "chalk": "~1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
- Update autoprefixer-core `^5.0.0` to latest `^5.1.7`
- Update chalk `~0.5.0` to latest `~1.0.0`  
- Update diff `~1.2.1` to  latest `~1.3.0`

The chalk library has released `1.0.0` after `0.5.1`, see https://github.com/sindresorhus/chalk/releases

nDmitry/grunt-autoprefixer#99 
