### PR TITLE
Sourcemap annotations should be string, not boolean, values

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,6 +129,16 @@ module.exports = function(grunt) {
                 src: 'test/fixtures/sm_inline_update.css',
                 dest: 'tmp/sm_inline_update.css'
             },
+            sm_annotation_path: {
+                options: {
+                    map: {
+                        inline: false,
+                        annotation: 'sm_updated_annotation.css.map'
+                    }
+                },
+                src: 'test/fixtures/sm_annotation_path.css',
+                dest: 'tmp/sm_annotation_path.css'
+            },
             log: {
                 src: 'tmp/single_file.css',
                 dest: 'tmp/single_file.css'

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can gain more control over sourcemap generation by setting an object to the 
 
 * `prev` (string or `false`): a path to a directory where a previous sourcemap is (e.g. `path/`). By default, Autoprefixer will try to find a previous sourcemap using a path from the annotation comment (or using the annotation comment itself if the map is inlined). You can also set this option to `false` to delete the previous sourcemap.
 * `inline` (boolean): whether a sourcemap will be inlined or not. By default, it will be the same as a previous sourcemap or inlined.
-* `annotation` (boolean or string): set this option to `true` or `false` to enable or disable annotation comments. You can also overwrite an output sourcemap path using this option, e.g. `path/file.css.map` (by default, Autoprefixer will save your sourcemap to a directory where you save CSS). This option requires `inline` to be `false` or undefined.
+* `annotation` (string): set this option to URL path you wish the annotation comment to be e.g. `path/file.css.map` (by default, Autoprefixer will save your sourcemap to a directory where you save CSS). This option requires `inline` to be `false` or undefined.
 * `sourcesContent` (boolean): whether original contents (e.g. Sass sources) will be included to a sourcemap. By default, Autoprefixer will add contents only for new sourcemaps or if a previous sourcemap has them.
 
 #### options.silent

--- a/tasks/autoprefixer.js
+++ b/tasks/autoprefixer.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
             map: (typeof options.map === 'boolean') ? options.map : {
                 prev: getPrevMap(from),
                 inline: (typeof options.map.inline === 'boolean') ? options.map.inline : true,
-                annotation: (typeof options.map.annotation === 'boolean') ? options.map.annotation : true,
+                annotation: (typeof options.map.annotation === 'string') ? options.map.annotation : true,
                 sourcesContent: (typeof options.map.sourcesContent === 'boolean') ? options.map.sourcesContent : true
             },
             from: from,

--- a/test/expected/sm_annotation_path.css
+++ b/test/expected/sm_annotation_path.css
@@ -1,0 +1,13 @@
+.bg1 {
+  background: -webkit-linear-gradient(black, #111111);
+  background: -moz-linear-gradient(black, #111111);
+  background: -o-linear-gradient(black, #111111);
+  background: linear-gradient(black, #111111); }
+
+.bg2 {
+  background: -webkit-linear-gradient(#111111, #222222);
+  background: -moz-linear-gradient(#111111, #222222);
+  background: -o-linear-gradient(#111111, #222222);
+  background: linear-gradient(#111111, #222222); }
+
+/*# sourceMappingURL=sm_updated_annotation.css.map */

--- a/test/fixtures/sm_annotation_path.css
+++ b/test/fixtures/sm_annotation_path.css
@@ -1,0 +1,13 @@
+.bg1 {
+  background: -webkit-linear-gradient(black, #111111);
+  background: -moz-linear-gradient(black, #111111);
+  background: -o-linear-gradient(black, #111111);
+  background: linear-gradient(black, #111111); }
+
+.bg2 {
+  background: -webkit-linear-gradient(#111111, #222222);
+  background: -moz-linear-gradient(#111111, #222222);
+  background: -o-linear-gradient(#111111, #222222);
+  background: linear-gradient(#111111, #222222); }
+
+/*# sourceMappingURL=sm_update.css.map */

--- a/test/test.js
+++ b/test/test.js
@@ -148,5 +148,13 @@ exports.autoprefixer = {
 
         test.strictEqual(actual, expected, 'should update an inlined source map.');
         test.done();
+    },
+
+    sm_annotation_path: function(test) {
+        var actual = grunt.file.read('tmp/sm_annotation_path.css');
+        var expected = grunt.file.read('test/expected/sm_annotation_path.css');
+
+        test.strictEqual(actual, expected, 'should update sourcemap annotation.');
+        test.done();
     }
 };


### PR DESCRIPTION
- See postcss/autoprefixer docs:
  https://github.com/postcss/autoprefixer/blob/master/README.md#source-map

- Adds test to assert a string annotation is handled correctly

I came across this because in my project's ``Gruntfile.js`` I use LESS to generate a sourcemap and add an annotation to the output, then run autoprefixer however this meant it would generate a new sourcemap based on the single ``.css`` output from LESS and so the sourcemap didn't actually map the LESS files used to build it. 

With this change the the ``annotation`` option will take a string which will specify what the annotation comment value should be, which the autoprefixer then updates the outputted CSS with.