### PR TITLE
Update autoprefixer.js

### DIFF
--- a/tasks/autoprefixer.js
+++ b/tasks/autoprefixer.js
@@ -77,7 +77,6 @@ module.exports = function(grunt) {
 
         var done = this.async();
         var finished = 0;
-        var processed = this.files.length;
 
         if (!this.files.length) {
             done();
@@ -129,7 +128,7 @@ module.exports = function(grunt) {
 
                     finished += 1;
 
-                    if (finished === processed) {
+                    if (finished === src.length) {
                         if (tally.sheets) {
                             grunt.log.ok(tally.sheets + ' ' + 'autoprefixed ' + grunt.util.pluralize(tally.sheets, 'stylesheet/stylesheets') + ' created.');
                         }


### PR DESCRIPTION
in the case your `src` contains a wild card and selects more than one file the counter should also work.
For instance `src: 'dist/css/*.css'` used in https://github.com/twbs/bootstrap/blob/v4-dev/Gruntfile.js#L244