### PR TITLE
Update autoprefixer.js

### DIFF
--- a/tasks/autoprefixer.js
+++ b/tasks/autoprefixer.js
@@ -99,7 +99,9 @@ module.exports = function(grunt) {
 
                 return done();
             }
-
+            if(src.length > 1) 
+                processed += src.length - 1; 
+            }
             src.forEach(function(filepath) {
                 var dest = f.dest || filepath;
                 var input = grunt.file.read(filepath);


### PR DESCRIPTION
in the case your `src` contains a wild card and selects more than one file the counter should also work.
For instance `src: 'dist/css/*.css' ` used in https://github.com/twbs/bootstrap/blob/v4-dev/Gruntfile.js#L244